### PR TITLE
Redirect to operator when asked

### DIFF
--- a/sd_food_bank_ai_bot/admin_panel/views.py
+++ b/sd_food_bank_ai_bot/admin_panel/views.py
@@ -9,7 +9,7 @@ from .models import FAQ, Tag, Log
 from .forms import FAQForm
 import json
 from django.http import HttpResponse
-from twilio.twiml.voice_response import VoiceResponse, Gather, Say
+from twilio.twiml.voice_response import VoiceResponse, Gather, Say, Dial
 from openai import OpenAI
 import urllib.parse
 import datetime
@@ -192,6 +192,7 @@ def call_status_update(request):
     else:
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
+@csrf_exempt
 def prompt_question(request):
     """
     Used to prompt the user for a question. Main use is to loop till end of call.
@@ -281,6 +282,15 @@ def confirm_question(request, question):
         response_pred = completion.choices[0].message.content
         if response_pred.upper() == "AFFIRMATIVE":
             question = urllib.parse.unquote(question)
+
+            if "operator" in question:
+                caller_response.say("I'm transferring you to an operator now. Please hold.")
+                dial = Dial()
+                dial.number("949-280-1506")
+                caller_response.append(dial)
+
+                return HttpResponse(str(caller_response), content_type="text/xml")
+
             answer = get_corresponding_answer(request, question)
             
             caller_response.say(answer)
@@ -344,6 +354,7 @@ def get_matching_question(request, question):
     # Gather all questions to be used in prompt
     questions = FAQ.objects.values_list('question', flat=True)
     questions = [question for question in questions]
+    questions.append("Can I speak to an operator?")
 
     # Set the system prompt to provide instructions on what to do
     system_prompt = f"You are a food pantry assistant with one job. When a user sends you a question, you find the closest match from questions you have memorized and respond with that question. If the question the user asks does not match any of your stored questions, respond with NONE. Only respond with the matching question or NONE.\nYour memorized questions are:{questions}"

--- a/sd_food_bank_ai_bot/admin_panel/views.py
+++ b/sd_food_bank_ai_bot/admin_panel/views.py
@@ -286,7 +286,7 @@ def confirm_question(request, question):
             if "operator" in question:
                 caller_response.say("I'm transferring you to an operator now. Please hold.")
                 dial = Dial()
-                dial.number("949-280-1506")
+                dial.number("###-###-####")
                 caller_response.append(dial)
 
                 return HttpResponse(str(caller_response), content_type="text/xml")


### PR DESCRIPTION
# Overview

**Type of Change:**
New Feature

**Summary:**
When the user asks to be redirected to an operator, they will be forwarded to an operator.

## UI/UX Implementation
No changes made.

## Model Updates
No changes made.

### Data Models
No changes made.

### Object-Oriented Models
No changes made.

## End-to-End Testing Instructions
Call the Twilio number. When prompted, ask to speak to an operator. Confirm that it forwards the call.
