### PR TITLE
Implemented multilingual support for faqs

### DIFF
--- a/sd_food_bank_ai_bot/admin_panel/tests/phone_service_faq_tests.py
+++ b/sd_food_bank_ai_bot/admin_panel/tests/phone_service_faq_tests.py
@@ -141,6 +141,9 @@ class PhoneFAQService(TestCase):
                                         answer="You must have an appointment.")
         self.faq_3 = FAQ.objects.create(question="How can I schedule an appointment?",
                                         answer="To schedule an appointment, visit calendly.com/sdfb.")
+        
+        self.user_eng = User.objects.create(first_name="John", last_name="Doe", phone_number="+17601231234")
+        self.user_span = User.objects.create(first_name="Jane", last_name="Doe", phone_number="+17603214321", language="es")
 
     @patch("admin_panel.views.phone_service_faq.get_matching_question")
     def test_get_question_from_user_valid(self, mock_get_matching_question):
@@ -149,11 +152,30 @@ class PhoneFAQService(TestCase):
         mock_get_matching_question.return_value = question  # Avoids API call
 
         request = self.factory.post("/get_question_from_user/",
-                                    {"SpeechResult": "What time do you open?"})
+                                    {"SpeechResult": "What time do you open?",
+                                     "From": "+17601231234"})
         response = get_question_from_user(request)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(f"You asked: {question} Is this correct?",
+                      response.content.decode())
+    
+    @patch("admin_panel.views.phone_service_faq.get_matching_question")
+    @patch("admin_panel.views.phone_service_faq.translate_to_language")
+    def test_get_question_from_user_valid_spanish(self, mock_translate_to_language, mock_get_matching_question):
+        """Test for when a valid question is asked in Spanish"""
+        question = "¿Cuándo abre el banco de alimentos?"
+        mock_translate_to_language.return_value = "Translated to Spanish"
+        mock_get_matching_question.return_value = question  # Avoids API call
+
+        request = self.factory.post("/get_question_from_user/",
+                                    {"SpeechResult": "¿Cuándo abre el banco de alimentos?",
+                                     "From": "+17603214321"})
+        response = get_question_from_user(request)
+
+        mock_translate_to_language.assert_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f"Preguntaste: Translated to Spanish",
                       response.content.decode())
 
     @patch("admin_panel.views.phone_service_faq.get_matching_question")
@@ -162,32 +184,81 @@ class PhoneFAQService(TestCase):
         mock_get_matching_question.return_value = None
 
         request = self.factory.post("/get_question_from_user/",
-                                    {"SpeechResult": "What time do you open?"})
+                                    {"SpeechResult": "What time do you open?",
+                                     "From": "+17601231234"})
         response = get_question_from_user(request)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Sorry, I don't have the answer to that at this time. Maybe try rephrasing your question.", response.content.decode())
 
     @patch("admin_panel.views.phone_service_faq.get_matching_question")
+    @patch("admin_panel.views.phone_service_faq.translate_to_language")
+    def test_get_question_from_user_invalid_spanish(self, mock_translate_to_language, mock_get_matching_question):
+        """Test for when a question did not match in Spanish"""
+        mock_translate_to_language.return_value = "Translated to Spanish"
+        mock_get_matching_question.return_value = None  # Avoids API call
+
+        request = self.factory.post("/get_question_from_user/",
+                                    {"SpeechResult": "¿Cuándo abre el banco de alimentos?",
+                                     "From": "+17603214321"})
+        response = get_question_from_user(request)
+
+        mock_translate_to_language.assert_called() # To translate asked question to english
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Lo siento, no tengo la respuesta en este momento.",
+                      response.content.decode())
+
+    @patch("admin_panel.views.phone_service_faq.get_matching_question")
     def test_get_question_from_user_unheard(self, mock_get_matching_question):
         """Test for when the bot does not receive an input"""
         mock_get_matching_question.return_value = None
 
-        request = self.factory.post("/get_question_from_user/", {"SpeechResult": ""})
+        request = self.factory.post("/get_question_from_user/", {"SpeechResult": "",
+                                                                 "From": "+17601231234"})
         response = get_question_from_user(request)
 
         self.assertEqual(response.status_code, 200)
         mock_get_matching_question.assert_not_called()
         self.assertIn("Sorry, I couldn't understand that.", response.content.decode())
 
-    def test_prompt_question(self):
-        """Test for prompting the user for input"""
+    @patch("admin_panel.views.phone_service_faq.get_matching_question")
+    @patch("admin_panel.views.phone_service_faq.translate_to_language")
+    def  test_get_question_from_user_unheard_spanish(self, mock_translate_to_language, mock_get_matching_question):
+        """Test for when the bot does not receive an input in Spanish"""
+        mock_translate_to_language.return_value = "Translated to Spanish"
+        mock_get_matching_question.return_value = None  # Avoids API call
+
+        request = self.factory.post("/get_question_from_user/",
+                                    {"SpeechResult": "",
+                                     "From": "+17603214321"})
+        response = get_question_from_user(request)
+
+        mock_translate_to_language.assert_not_called()
+        mock_get_matching_question.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Lo siento, no pude entender eso.",
+                      response.content.decode())
+
+    def test_prompt_question_english(self):
+        """Test for prompting the user for input in English"""
         self.client = Client()
 
-        response = self.client.get(reverse("prompt_question"), follow=False)
+        content = {"From": "+17601231234"}
+        response = self.client.post(reverse("prompt_question"), content, follow=False)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("What can I help you with?", response.content.decode())
+    
+    def test_prompt_question_spanish(self):
+        """Test for prompting the user for input in Spanish"""
+        self.client = Client()
+
+        content = {"From": "+17603214321"}
+        response = self.client.post(reverse("prompt_question"), content, follow=False)
+
+        self.assertEqual(response.status_code, 200)
+        # Can't give full sentence because of encoding of special symbols
+        self.assertIn("puedo ayudarte?", response.content.decode())
 
     @patch("admin_panel.views.phone_service_faq.get_response_sentiment")
     @patch("admin_panel.views.phone_service_faq.get_corresponding_answer")
@@ -200,11 +271,29 @@ class PhoneFAQService(TestCase):
 
         question = "When does the food bank open?"
         question_encoded = urllib.parse.quote(question)
-        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "Yes"})
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "Yes",
+                                                                               "From": "+17601231234"})
         response = confirm_question(request, question_encoded)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("The food bank is open Monday-Friday from 9:00 AM to 5:00 PM", response.content.decode())
+    
+    @patch("admin_panel.views.phone_service_faq.get_response_sentiment")
+    @patch("admin_panel.views.phone_service_faq.translate_to_language")
+    def test_confirm_question_affirmative_spanish(self, mock_translate_to_language,
+                                          mock_get_response_sentiment):
+        """Test for when the user has said the question is correct in Spanish"""
+        mock_get_response_sentiment.return_value = True
+        mock_translate_to_language.return_value = "Translated to Spanish"
+
+        question = "When does the food bank open?" # In English because passed as parameter from other function
+        question_encoded = urllib.parse.quote(question)
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "Sí",
+                                                                               "From": "+17603214321"})
+        response = confirm_question(request, question_encoded)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Translated to Spanish", response.content.decode())
 
     @patch("admin_panel.views.phone_service_faq.get_response_sentiment")
     @patch("admin_panel.views.phone_service_faq.get_corresponding_answer")
@@ -214,7 +303,8 @@ class PhoneFAQService(TestCase):
 
         question = "Can I speak to an operator?"
         question_encoded = urllib.parse.quote(question)
-        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "Yes"})
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "Yes",
+                                                                               "From": "+17601231234"})
         response = confirm_question(request, question_encoded)
 
         self.assertEqual(response.status_code, 200)
@@ -229,11 +319,45 @@ class PhoneFAQService(TestCase):
 
         question = "When does the food bank open?"
         question_encoded = urllib.parse.quote(question)
-        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "Yes"})
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "No",
+                                                                               "From": "+17601231234"})
         response = confirm_question(request, question_encoded)
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("Sorry about that. Please try asking again or rephrasing.", response.content.decode())
+    
+    @patch("admin_panel.views.phone_service_faq.get_response_sentiment")
+    @patch("admin_panel.views.phone_service_faq.translate_to_language")
+    def test_confirm_question_negative_spanish(self, mock_translate_to_language, mock_get_response_sentiment):
+        """Test for when the user has said the question is incorrect in spanish"""
+        mock_translate_to_language.return_vaue = "Translated to Spanish"
+        mock_get_response_sentiment.return_value = False
+
+        question = "When does the food bank open?" # Passed as parameter from a different function, so in English
+        question_encoded = urllib.parse.quote(question)
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "No",
+                                                                               "From": "+17603214321"})
+        response = confirm_question(request, question_encoded)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Lo siento. Intenta preguntar de nuevo o reformula tu pregunta.", response.content.decode())
+
+    @patch("admin_panel.views.phone_service_faq.get_response_sentiment")
+    @patch("admin_panel.views.phone_service_faq.translate_to_language")
+    def test_confirm_question_unheard(self, mock_translate_to_language, mock_get_response_sentiment):
+        """Test for when the bot receives no input"""
+        mock_translate_to_language.return_value = "Translated to Spanish"
+        mock_get_response_sentiment.return_value = False
+
+        question = "When does the food bank open?" # In English because previously translated
+        question_encoded = urllib.parse.quote(question)
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "",
+                                                                               "From": "+17603214321"})
+        response = confirm_question(request, question_encoded)
+
+        mock_get_response_sentiment.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Lo siento, no pude entender eso.", response.content.decode())
 
     @patch("admin_panel.views.phone_service_faq.get_response_sentiment")
     def test_confirm_question_unheard(self, mock_get_response_sentiment):
@@ -242,7 +366,8 @@ class PhoneFAQService(TestCase):
 
         question = "When does the food bank open?"
         question_encoded = urllib.parse.quote(question)
-        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": ""})
+        request = self.factory.post(f"/confirm_question/{question_encoded}/", {"SpeechResult": "",
+                                                                               "From": "+17601231234"})
         response = confirm_question(request, question_encoded)
 
         mock_get_response_sentiment.assert_not_called()

--- a/sd_food_bank_ai_bot/admin_panel/views/phone_service_faq.py
+++ b/sd_food_bank_ai_bot/admin_panel/views/phone_service_faq.py
@@ -9,11 +9,11 @@ from .utilities import (strike_system_handler, forward_operator, write_to_log,
                         get_response_sentiment,
                         get_matching_question, get_corresponding_answer)
 from .phone_service_schedule import CALLER, BOT
-from .utilities import get_phone_number
+from .utilities import get_phone_number, translate_to_language
 from ..models import User
 
 
-TIMEOUT_LENGTH = 3  # The length of time the bot waits for a response
+TIMEOUT_LENGTH = 5  # The length of time the bot waits for a response
 
 
 @csrf_exempt
@@ -63,7 +63,7 @@ def answer_call(request):
         if user.language == "en":
             gather.say("Thank you for calling the San Diego Food Bank!", language="en")
             write_to_log(log, BOT, "Thank you for calling the San Diego Food Bank!")
-            gather.say("Para español presione 0.", language="es")
+            gather.say("Para español presione 0.", language="es-MX")
             write_to_log(log, BOT, "Para español presione 0.")
             gather.say("press 1 to schedule an appointment, press 2 to reschedule an appointment,\
                         press 3 to cancel an appointment, press 4 to ask about specific inquiries,\
@@ -72,13 +72,13 @@ def answer_call(request):
                         press 3 to cancel an appointment, press 4 to ask about specific inquiries,\
                         or press 5 to be forwarded to an operator.")
         else:
-            gather.say("Gracias por llamar al banco de alimentos de San Diego!", language="es")
+            gather.say("Gracias por llamar al banco de alimentos de San Diego!", language="es-MX")
             write_to_log(log, BOT, "Gracias por llamar al banco de alimentos de San Diego!")
             gather.say("For english press 0.", language="en")
             write_to_log(log, BOT, "For english press 0.")
             gather.say("presione 1 para programar una cita, presione 2 para reprogramar una cita, presione\
                         3 para cancelar una cita, presione 4 para preguntar sobre consultas específicas\
-                        o presione 5 para ser remitido a un operador.", language="es")
+                        o presione 5 para ser remitido a un operador.", language="es-MX")
             write_to_log(log, BOT, "presione 1 para programar una cita, presione 2 para reprogramar una cita, presione\
                         3 para cancelar una cita, presione 4 para preguntar sobre consultas específicas\
                         o presione 5 para ser remitido a un operador.")
@@ -132,10 +132,19 @@ def prompt_question(request):
     phone_number = request.POST.get('From')
     log = Log.objects.filter(phone_number=phone_number).last()
     caller_response = VoiceResponse()
-    gather = Gather(input="speech", timeout=TIMEOUT_LENGTH,
-                    action="/get_question_from_user/")
-    gather.say("What can I help you with?")
-    write_to_log(log, BOT, "What can I help you with?")
+    
+    user = User.objects.get(phone_number=phone_number)
+    gather = None
+    if user.language == "en":
+        gather = Gather(input="speech", timeout=TIMEOUT_LENGTH,
+                        action="/get_question_from_user/", language="en")
+        gather.say("What can I help you with?", language="en")
+        write_to_log(log, BOT, "What can I help you with?")
+    else:
+        gather = Gather(input="speech", timeout=TIMEOUT_LENGTH,
+                        action="/get_question_from_user/", language="es-MX")
+        gather.say("¿En qué puedo ayudarte?", language="es-MX")
+        write_to_log(log, BOT, "¿En qué puedo ayudarte?")
     caller_response.append(gather)
 
     return HttpResponse(str(caller_response), content_type='text/xml')
@@ -151,24 +160,47 @@ def get_question_from_user(request):
     log = Log.objects.filter(phone_number=phone_number).last()
     write_to_log(log, CALLER, speech_result)
     caller_response = VoiceResponse()
+
+    user = User.objects.get(phone_number=phone_number)
     if speech_result:
+        if user.language == "es":
+            speech_result = translate_to_language(source_lang="es", target_lang="en", text=speech_result)
         question = get_matching_question(speech_result)
         if question:
             question_encoded = urllib.parse.quote(question)
-            gather = Gather(input="speech", timeout=TIMEOUT_LENGTH,
-                            action=f"/confirm_question/{question_encoded}/")
-            gather.say(f"You asked: {question} Is this correct?")
-            write_to_log(log, BOT, f"You asked: {question} Is this correct?")
+            gather = None
+            
+            if user.language == "en":
+                gather = Gather(input="speech", timeout=TIMEOUT_LENGTH,
+                                action=f"/confirm_question/{question_encoded}/", language="en")
+                gather.say(f"You asked: {question} Is this correct?")
+                write_to_log(log, BOT, f"You asked: {question} Is this correct?")
+            else:
+                question = translate_to_language(source_lang="en", target_lang="es", text=question)
+                gather = Gather(input="speech", timeout=TIMEOUT_LENGTH,
+                                action=f"/confirm_question/{question_encoded}/", language="es-MX")
+                gather.say(f"Preguntaste: {question} ¿Es esto correcto?", language="es-MX")
+                write_to_log(log, BOT, f"Preguntaste: {question} ¿Es esto correcto?")
+
             caller_response.append(gather)
         else:  # No matching question found
             # Add a strike
             strike_system_handler(log)
-            caller_response.say("Sorry, I don't have the answer to that at this time. Maybe try rephrasing your question.")
-            write_to_log(log, BOT, "Sorry, I don't have the answer to that at this time. Maybe try rephrasing your question.")
+            if user.language == "en":
+                caller_response.say("Sorry, I don't have the answer to that at this time. Maybe try rephrasing your question.")
+                write_to_log(log, BOT, "Sorry, I don't have the answer to that at this time. Maybe try rephrasing your question.")
+            else:
+                caller_response.say("Lo siento, no tengo la respuesta en este momento. Quizás podrías intentar reformular tu pregunta.", language="es-MX")
+                write_to_log(log, BOT, "Lo siento, no tengo la respuesta en este momento. Quizás podrías intentar reformular tu pregunta.")
+
             caller_response.redirect("/prompt_question/")
     else:
-        caller_response.say("Sorry, I couldn't understand that.")
-        write_to_log(log, BOT, "Sorry, I couldn't understand that.")
+        if user.language == "en":
+            caller_response.say("Sorry, I couldn't understand that.")
+            write_to_log(log, BOT, "Sorry, I couldn't understand that.")
+        else:
+            caller_response.say("Lo siento, no pude entender eso.", language="es-MX")
+            write_to_log(log, BOT, "Lo siento, no pude entender eso.")
 
     return HttpResponse(str(caller_response), content_type='text/xml')
 
@@ -183,8 +215,12 @@ def confirm_question(request, question):
     log = Log.objects.filter(phone_number=phone_number).last()
     caller_response = VoiceResponse()
     write_to_log(log, CALLER, speech_result)
-
+    
+    user = User.objects.get(phone_number=phone_number)
     if speech_result:
+        if user.language == "es":
+            speech_result = translate_to_language("es", "en", speech_result)
+
         sentiment = get_response_sentiment(speech_result)
         if sentiment:
             question = urllib.parse.unquote(question)
@@ -194,7 +230,11 @@ def confirm_question(request, question):
 
             answer = get_corresponding_answer(question)
 
-            caller_response.say(answer)
+            if user.language == "en":
+                caller_response.say(answer)
+            else:
+                answer = translate_to_language("en", "es", answer)
+                caller_response.say(answer, language="es-MX")
             write_to_log(log, BOT, answer)
 
             caller_response.redirect("/prompt_question/")
@@ -203,12 +243,20 @@ def confirm_question(request, question):
         else:
             # Add a strike
             strike_system_handler(log)
-            caller_response.say("Sorry about that. Please try asking again or rephrasing.")
-            write_to_log(log, BOT, "Sorry about that. Please try asking again or rephrasing.")
+            if user.language == "en":
+                caller_response.say("Sorry about that. Please try asking again or rephrasing.")
+                write_to_log(log, BOT, "Sorry about that. Please try asking again or rephrasing.")
+            else:
+                caller_response.say("Lo siento. Intenta preguntar de nuevo o reformula tu pregunta.", language="es-MX")
+                write_to_log(log, BOT, "Lo siento. Intenta preguntar de nuevo o reformula tu pregunta.")
             caller_response.redirect("/prompt_question/")
     else:
-        caller_response.say("Sorry, I couldn't understand that. Please try again.")
-        write_to_log(log, BOT, "Sorry, I couldn't understand that. Please try again.")
+        if user.language == "en":
+            caller_response.say("Sorry, I couldn't understand that. Please try again.")
+            write_to_log(log, BOT, "Sorry, I couldn't understand that. Please try again.")
+        else:
+            caller_response.say("Lo siento, no pude entender eso. Por favor inténtalo de nuevo.")
+            write_to_log(log, BOT, "Lo siento, no pude entender eso. Por favor inténtalo de nuevo.")
         caller_response.redirect("/prompt_question/")
 
     return HttpResponse(str(caller_response), content_type='text/xml')

--- a/sd_food_bank_ai_bot/admin_panel/views/utilities.py
+++ b/sd_food_bank_ai_bot/admin_panel/views/utilities.py
@@ -28,7 +28,7 @@ def strike_system_handler(log, reset=False):
         else:
 
             if log.add_strike():
-                forward_operator()
+                forward_operator(log)
 
 
 def get_phone_number(request):


### PR DESCRIPTION
# Overview

**Type of Change:** 
New Feature

**Summary:**
Added support for Spanish when asking an faq.

## UI/UX Implementation
All FAQ English dialog now has a Spanish counterpart.

## Model Updates
No changes made.

### Data Models
No changes made.

### Object-Oriented Models
No changes made.

## End-to-End Testing Instructions
Call the food bank and press 0 to change language to Spanish. Press 4 to ask an FAQ. Confrim that you are prompted in Spanish. Answer in Spanish and confirm that your question is repeated for confirmation in Spanish. Agree in Spanish. Confirm you are given the answer in Spanish and reprompted.